### PR TITLE
Add workflow generator prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pkl
+
+# Node
+node_modules/
+
+# Environment
+.env
+
+# Misc
+*.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# AI Build Projects
+
+This repository contains various AI workflow examples and agents. A new prototype has been added in `workflow_generator/`.
+
+- `workflow_generator/` – minimal backend and frontend for generating n8n workflows from images, text or YouTube links. Real OCR and LLM processing should be integrated later.

--- a/workflow_generator/README.md
+++ b/workflow_generator/README.md
@@ -1,0 +1,19 @@
+# Workflow Generator
+
+This is a minimal prototype for generating n8n workflows from an image, text description or YouTube URL.
+
+## Backend
+
+A FastAPI server exposes a `/generate` endpoint. Real OCR, language model and video processing should be added where noted.
+
+```
+cd backend
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+## Frontend
+
+Open `frontend/index.html` in a browser. Submit an image, text or YouTube URL to test the API.
+
+This project is a skeleton and does not implement real AI processing yet.

--- a/workflow_generator/backend/main.py
+++ b/workflow_generator/backend/main.py
@@ -1,0 +1,48 @@
+from fastapi import FastAPI, File, UploadFile, Form
+from fastapi.responses import JSONResponse
+from typing import Optional
+
+app = FastAPI(title="Workflow Generator")
+
+
+def process_image(image_bytes: bytes) -> dict:
+    """Placeholder image processing to generate workflow JSON."""
+    # TODO: integrate OCR and structural analysis
+    return {"workflow": "from image"}
+
+
+def process_text(description: str) -> dict:
+    """Placeholder text processing to generate workflow JSON."""
+    # TODO: integrate LLM for workflow generation
+    return {"workflow": "from text"}
+
+
+def process_youtube(url: str) -> dict:
+    """Placeholder YouTube processing to generate workflow JSON."""
+    # TODO: fetch transcript and use LLM
+    return {"workflow": "from youtube"}
+
+
+@app.post("/generate")
+async def generate(
+    description: Optional[str] = Form(None),
+    youtube_url: Optional[str] = Form(None),
+    image: Optional[UploadFile] = File(None),
+):
+    if image is not None:
+        content = await image.read()
+        result = process_image(content)
+    elif description:
+        result = process_text(description)
+    elif youtube_url:
+        result = process_youtube(youtube_url)
+    else:
+        return JSONResponse(status_code=400, content={"error": "No valid input"})
+
+    return result
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/workflow_generator/backend/requirements.txt
+++ b/workflow_generator/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/workflow_generator/frontend/index.html
+++ b/workflow_generator/frontend/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Workflow Generator</title>
+</head>
+<body>
+    <h1>Workflow Generator</h1>
+    <form id="workflow-form">
+        <textarea name="description" placeholder="Description"></textarea><br>
+        <input type="text" name="youtube_url" placeholder="YouTube URL"><br>
+        <input type="file" name="image"><br>
+        <button type="submit">Generate</button>
+    </form>
+    <pre id="result"></pre>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/workflow_generator/frontend/script.js
+++ b/workflow_generator/frontend/script.js
@@ -1,0 +1,13 @@
+document.getElementById('workflow-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const form = e.target;
+    const data = new FormData(form);
+
+    const response = await fetch('http://localhost:8000/generate', {
+        method: 'POST',
+        body: data
+    });
+
+    const result = await response.json();
+    document.getElementById('result').textContent = JSON.stringify(result, null, 2);
+});


### PR DESCRIPTION
## Summary
- add a `.gitignore`
- document projects in new README
- scaffold `workflow_generator` with FastAPI backend and simple HTML frontend

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684ee9fe00708324a59e7df309f12465