### PR TITLE
feat: ajouter générateur de workflows n8n

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,74 @@
+# Générateur de workflows n8n
+
+Cette application Node.js/TypeScript génère et valide des workflows [n8n](https://n8n.io) à partir d'une spécification textuelle, image ou vidéo.
+
+## Prérequis
+
+- [Node.js](https://nodejs.org/) >= 18
+- [pnpm](https://pnpm.io/) >= 8
+- Une clé API OpenAI disponible dans la variable d'environnement `OPENAI_API_KEY`
+- Toutes les informations d'identification requises exposées via des variables `CREDENTIALS.*`
+
+## Installation
+
+```bash
+pnpm install
+```
+
+## Génération d'un workflow
+
+```bash
+pnpm gen "Ma spec ultra-précise"
+```
+
+Le script construit une requête OpenAI à partir des prompts systèmes et développeur, applique les few-shots puis enregistre le JSON produit dans `workflow.generated.json`.
+
+## Validation d'un workflow
+
+```bash
+pnpm val workflow.generated.json
+```
+
+Le script `validate` applique le schéma JSON strict (`schemas/n8n-workflow.schema.json`) via [Ajv](https://ajv.js.org/). Toute propriété inconnue provoque un échec.
+
+## Import dans n8n
+
+Le fichier JSON généré peut être importé directement dans l'interface n8n (menu **Workflows > Import from File**).
+
+## Personnalisation
+
+- Modifiez les prompts dans `system/` pour imposer vos conventions internes.
+- Ajoutez ou adaptez des exemples dans `src/examples/` pour servir de référence aux tests et à la validation manuelle.
+- Enrichissez les few-shots dans `system/FEW_SHOTS.md` pour guider la génération de workflows spécifiques.
+
+## Tests
+
+Des exemples sont fournis dans `src/examples/`. Vous pouvez les valider avec :
+
+```bash
+pnpm val src/examples/basic-webhook.json
+```
+
+## Structure du projet
+
+```
+├─ README.md
+├─ system/
+│  ├─ SYSTEM_PROMPT.fr.md
+│  ├─ DEV_PROMPT.fr.md
+│  └─ FEW_SHOTS.md
+├─ schemas/
+│  └─ n8n-workflow.schema.json
+├─ src/
+│  ├─ generate.ts
+│  ├─ validate.ts
+│  ├─ types.ts
+│  └─ examples/
+│     ├─ basic-webhook.json
+│     └─ vision-llm-sheets.json
+└─ package.json
+```
+
+## Licence
+
+Distribué sous licence MIT.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "n8n-workflow-generator",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "gen": "tsx src/generate.ts",
+    "val": "tsx src/validate.ts",
+    "test": "pnpm val src/examples/basic-webhook.json && pnpm val src/examples/vision-llm-sheets.json"
+  },
+  "dependencies": {
+    "ajv": "^8.12.0",
+    "ajv-formats": "^2.1.1",
+    "openai": "^4.47.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/schemas/n8n-workflow.schema.json
+++ b/schemas/n8n-workflow.schema.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/schemas/n8n-workflow.schema.json",
+  "title": "n8n Workflow",
+  "type": "object",
+  "required": ["nodes", "connections", "active", "settings", "meta", "version"],
+  "additionalProperties": false,
+  "properties": {
+    "nodes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/node" }
+    },
+    "connections": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": { "$ref": "#/definitions/connectionMap" }
+    },
+    "active": { "type": "boolean" },
+    "settings": {
+      "type": "object",
+      "additionalProperties": false
+    },
+    "meta": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "definitions": {
+    "node": {
+      "type": "object",
+      "required": ["id", "name", "type", "position", "parameters"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_-]+$"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "n8n-nodes-base.httpRequest",
+            "n8n-nodes-base.set",
+            "n8n-nodes-base.if",
+            "n8n-nodes-base.function",
+            "n8n-nodes-base.googleSheets",
+            "n8n-nodes-base.openAi",
+            "n8n-nodes-base.webhook"
+          ]
+        },
+        "position": {
+          "type": "object",
+          "required": ["x", "y"],
+          "additionalProperties": false,
+          "properties": {
+            "x": { "type": "number" },
+            "y": { "type": "number" }
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "credentials": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": false,
+          "patternProperties": {
+            "^[A-Za-z0-9_-]+$": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "pattern": "^\\\\{\\\\{CREDENTIALS\\.[A-Z0-9_]+\\\\}\\\\}$"
+                },
+                {
+                  "type": "string",
+                  "pattern": "^\\{\\{CREDENTIALS\\.[A-Z0-9_]+\\}\\}$"
+                }
+              ]
+            }
+          }
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "connectionMap": {
+      "type": "object",
+      "required": ["main"],
+      "additionalProperties": false,
+      "properties": {
+        "main": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": { "$ref": "#/definitions/connection" }
+          }
+        }
+      }
+    },
+    "connection": {
+      "type": "object",
+      "required": ["node", "type", "index"],
+      "additionalProperties": false,
+      "properties": {
+        "node": { "type": "string", "minLength": 1 },
+        "type": { "type": "string", "enum": ["main"] },
+        "index": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/src/examples/basic-webhook.json
+++ b/src/examples/basic-webhook.json
@@ -1,0 +1,66 @@
+{
+  "nodes": [
+    {
+      "id": "n1",
+      "name": "Webhook Entrant",
+      "type": "n8n-nodes-base.webhook",
+      "position": { "x": 260, "y": 200 },
+      "parameters": {
+        "path": "lead-inbound",
+        "httpMethod": "POST",
+        "responseMode": "onReceived"
+      }
+    },
+    {
+      "id": "n2",
+      "name": "Formater Payload",
+      "type": "n8n-nodes-base.set",
+      "position": { "x": 520, "y": 400 },
+      "parameters": {
+        "keepOnlySet": true,
+        "values": {
+          "string": [
+            { "name": "email", "value": "={{$json.body.email}}" },
+            { "name": "source", "value": "Landing Page" }
+          ]
+        }
+      }
+    },
+    {
+      "id": "n3",
+      "name": "Insérer Google Sheets",
+      "type": "n8n-nodes-base.googleSheets",
+      "position": { "x": 780, "y": 600 },
+      "parameters": {
+        "operation": "append",
+        "sheetId": "={{$env.SHEET_ID}}",
+        "columns": ["email", "source"]
+      },
+      "credentials": {
+        "googleApi": "{{CREDENTIALS.GOOGLE_API}}"
+      }
+    }
+  ],
+  "connections": {
+    "Webhook Entrant": {
+      "main": [
+        [
+          { "node": "Formater Payload", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Formater Payload": {
+      "main": [
+        [
+          { "node": "Insérer Google Sheets", "type": "main", "index": 0 }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {},
+  "meta": {
+    "template": "basic-webhook"
+  },
+  "version": 1
+}

--- a/src/examples/vision-llm-sheets.json
+++ b/src/examples/vision-llm-sheets.json
@@ -1,0 +1,98 @@
+{
+  "nodes": [
+    {
+      "id": "n1",
+      "name": "Webhook Média",
+      "type": "n8n-nodes-base.webhook",
+      "position": { "x": 260, "y": 200 },
+      "parameters": {
+        "path": "media-intake",
+        "httpMethod": "POST"
+      }
+    },
+    {
+      "id": "n2",
+      "name": "Analyser Média",
+      "type": "n8n-nodes-base.openAi",
+      "position": { "x": 520, "y": 400 },
+      "parameters": {
+        "operation": "chat",
+        "model": "gpt-4.1-mini",
+        "inputType": "json",
+        "jsonParameters": true,
+        "messages": [
+          {
+            "role": "system",
+            "content": "Tu es un assistant qui décrit précisément le contenu multimédia."
+          },
+          {
+            "role": "user",
+            "content": "={{$json.body.file}}"
+          }
+        ]
+      },
+      "credentials": {
+        "openAiApi": "{{CREDENTIALS.OPENAI_API}}"
+      }
+    },
+    {
+      "id": "n3",
+      "name": "Structurer Résumé",
+      "type": "n8n-nodes-base.set",
+      "position": { "x": 780, "y": 600 },
+      "parameters": {
+        "keepOnlySet": true,
+        "values": {
+          "string": [
+            { "name": "titre", "value": "={{$json.choices[0].message.title}}" },
+            { "name": "description", "value": "={{$json.choices[0].message.content}}" }
+          ]
+        }
+      }
+    },
+    {
+      "id": "n4",
+      "name": "Enregistrer Résumé",
+      "type": "n8n-nodes-base.googleSheets",
+      "position": { "x": 1040, "y": 800 },
+      "parameters": {
+        "operation": "append",
+        "sheetId": "={{$env.SHEET_ID}}",
+        "columns": ["titre", "description"]
+      },
+      "credentials": {
+        "googleApi": "{{CREDENTIALS.GOOGLE_API}}"
+      },
+      "notes": "Écrit le résumé structuré dans Google Sheets."
+    }
+  ],
+  "connections": {
+    "Webhook Média": {
+      "main": [
+        [
+          { "node": "Analyser Média", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Analyser Média": {
+      "main": [
+        [
+          { "node": "Structurer Résumé", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Structurer Résumé": {
+      "main": [
+        [
+          { "node": "Enregistrer Résumé", "type": "main", "index": 0 }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {},
+  "meta": {
+    "template": "vision-llm-sheets"
+  },
+  "version": 1
+}

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,0 +1,153 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import OpenAI from 'openai';
+
+import { GenerateOptions, Workflow } from './types.js';
+import { validateWorkflow } from './validate.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function loadFile(relativePath: string): Promise<string> {
+  const absolute = path.resolve(__dirname, '..', relativePath);
+  return fs.readFile(absolute, 'utf-8');
+}
+
+function extractJsonPayload(text: string): string {
+  const fenced = text.match(/```json\s*([\s\S]+?)```/i);
+  if (fenced?.[1]) {
+    return fenced[1].trim();
+  }
+  const genericFence = text.match(/```\s*([\s\S]+?)```/);
+  if (genericFence?.[1]) {
+    return genericFence[1].trim();
+  }
+  return text.trim();
+}
+
+async function callOpenAI(options: GenerateOptions): Promise<string> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY manquant dans les variables d\'environnement.');
+  }
+
+  const client = new OpenAI({ apiKey });
+
+  const [systemPrompt, devPrompt, fewShots, schema] = await Promise.all([
+    loadFile('system/SYSTEM_PROMPT.fr.md'),
+    loadFile('system/DEV_PROMPT.fr.md'),
+    loadFile('system/FEW_SHOTS.md'),
+    loadFile('schemas/n8n-workflow.schema.json'),
+  ]);
+
+  const response = await client.responses.create({
+    model: options.model ?? 'gpt-4.1-mini',
+    temperature: options.temperature ?? 0.2,
+    input: [
+      { role: 'system', content: systemPrompt },
+      { role: 'developer', content: devPrompt },
+      {
+        role: 'system',
+        content: `Schéma JSON strict (utiliser uniquement les propriétés définies) :\n${schema}`,
+      },
+      {
+        role: 'user',
+        content: `Exemples de workflows valides (few-shots) :\n${fewShots}`,
+      },
+      {
+        role: 'user',
+        content: `Spécification à implémenter :\n${options.spec}\n\nRetourne UNIQUEMENT le JSON du workflow.`,
+      },
+    ],
+  });
+
+  const outputText = (response.output_text ?? '').trim();
+  if (!outputText) {
+    throw new Error('Réponse vide reçue du modèle OpenAI.');
+  }
+
+  return extractJsonPayload(outputText);
+}
+
+export async function generateWorkflow(options: GenerateOptions): Promise<Workflow> {
+  const jsonText = await callOpenAI(options);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch (error) {
+    throw new Error(`La réponse du modèle n'est pas un JSON valide.\n${jsonText}`);
+  }
+
+  return validateWorkflow(parsed);
+}
+
+async function writeWorkflowFile(workflow: Workflow, outputPath: string): Promise<void> {
+  const content = `${JSON.stringify(workflow, null, 2)}\n`;
+  await fs.writeFile(outputPath, content, 'utf-8');
+}
+
+function parseArgs(argv: string[]): GenerateOptions {
+  const args = [...argv];
+  const specParts: string[] = [];
+  let outputPath: string | undefined;
+  let model: string | undefined;
+  let temperature: number | undefined;
+
+  while (args.length > 0) {
+    const token = args.shift();
+    if (!token) continue;
+    if (token.startsWith('--out=')) {
+      outputPath = token.split('=').slice(1).join('=');
+    } else if (token === '--out') {
+      outputPath = args.shift();
+    } else if (token.startsWith('--model=')) {
+      model = token.split('=').slice(1).join('=');
+    } else if (token === '--model') {
+      model = args.shift();
+    } else if (token.startsWith('--temperature=')) {
+      const value = token.split('=').slice(1).join('=');
+      temperature = Number(value);
+    } else if (token === '--temperature') {
+      const value = args.shift();
+      if (value !== undefined) {
+        temperature = Number(value);
+      }
+    } else {
+      specParts.push(token);
+    }
+  }
+
+  const spec = specParts.join(' ').trim();
+  if (!spec) {
+    throw new Error('Veuillez fournir une spécification en argument, par exemple: pnpm gen "Spec détaillée"');
+  }
+
+  return {
+    spec,
+    outputPath,
+    model,
+    temperature,
+  };
+}
+
+async function runCli(): Promise<void> {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const outputPath = path.resolve(process.cwd(), options.outputPath ?? 'workflow.generated.json');
+    const workflow = await generateWorkflow(options);
+    await writeWorkflowFile(workflow, outputPath);
+    console.log(`✅ Workflow généré et validé: ${outputPath}`);
+  } catch (error) {
+    console.error('❌ Échec de la génération du workflow.');
+    if (error instanceof Error) {
+      console.error(error.message);
+    }
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli();
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,53 @@
+export type AllowedNodeType =
+  | 'n8n-nodes-base.httpRequest'
+  | 'n8n-nodes-base.set'
+  | 'n8n-nodes-base.if'
+  | 'n8n-nodes-base.function'
+  | 'n8n-nodes-base.googleSheets'
+  | 'n8n-nodes-base.openAi'
+  | 'n8n-nodes-base.webhook';
+
+export interface NodePosition {
+  x: number;
+  y: number;
+}
+
+export interface NodeCredentials {
+  [key: string]: `{{CREDENTIALS.${string}}}`;
+}
+
+export interface WorkflowNode {
+  id: string;
+  name: string;
+  type: AllowedNodeType;
+  position: NodePosition;
+  parameters: Record<string, unknown>;
+  credentials?: NodeCredentials;
+  notes?: string;
+}
+
+export interface ConnectionReference {
+  node: string;
+  type: 'main';
+  index: number;
+}
+
+export interface ConnectionMap {
+  main: ConnectionReference[][];
+}
+
+export interface Workflow {
+  nodes: WorkflowNode[];
+  connections: Record<string, ConnectionMap>;
+  active: boolean;
+  settings: Record<string, never>;
+  meta: Record<string, unknown>;
+  version: number;
+}
+
+export interface GenerateOptions {
+  spec: string;
+  outputPath?: string;
+  model?: string;
+  temperature?: number;
+}

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import Ajv, { DefinedError } from 'ajv';
+import addFormats from 'ajv-formats';
+
+import { Workflow } from './types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const schemaPath = path.resolve(__dirname, '../schemas/n8n-workflow.schema.json');
+const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf-8'));
+
+const ajv = new Ajv({
+  allErrors: true,
+  strict: true,
+  allowUnionTypes: true,
+});
+addFormats(ajv);
+
+const validator = ajv.compile<Workflow>(schema);
+
+export function validateWorkflow(input: unknown): Workflow {
+  if (!validator(input)) {
+    const details = (validator.errors ?? [])
+      .map((error: DefinedError) => `${error.instancePath || '/'} ${error.message}`)
+      .join('\n');
+    throw new Error(`Workflow invalide selon le schéma n8n:\n${details}`);
+  }
+  return input as Workflow;
+}
+
+function validateFile(filePath: string): void {
+  const absolute = path.resolve(process.cwd(), filePath);
+  const raw = fs.readFileSync(absolute, 'utf-8');
+  const data = JSON.parse(raw);
+  validateWorkflow(data);
+  console.log(`✅ Workflow valide: ${absolute}`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const target = process.argv[2];
+  if (!target) {
+    console.error('Usage: pnpm val <chemin-vers-workflow.json>');
+    process.exitCode = 1;
+  } else {
+    try {
+      validateFile(target);
+    } catch (error) {
+      console.error('❌ Validation échouée.');
+      if (error instanceof Error) {
+        console.error(error.message);
+      }
+      process.exitCode = 1;
+    }
+  }
+}

--- a/system/DEV_PROMPT.fr.md
+++ b/system/DEV_PROMPT.fr.md
@@ -1,0 +1,9 @@
+Contexte développeur :
+- Nœuds disponibles : `n8n-nodes-base.httpRequest`, `n8n-nodes-base.set`, `n8n-nodes-base.if`, `n8n-nodes-base.function`, `n8n-nodes-base.googleSheets`, `n8n-nodes-base.openAi`, `n8n-nodes-base.webhook`.
+- Respecte le positionnement : commence à `{ "x": 260, "y": 200 }` pour le premier nœud, puis incrémente `x` de 260 et `y` de 200 pour chaque nœud suivant.
+- Toutes les connexions doivent utiliser la sortie `main[0][0]` vers l'entrée principale du nœud suivant.
+- Les credentials doivent être référencés avec des placeholders `{{CREDENTIALS.NAME}}` et respecter la regex du schéma.
+- Ajoute des notes lorsque la spec impose des détails importants ou des hypothèses.
+- Utilise les heuristiques d'atomicité : un nœud par responsabilité métier.
+- Prévois un fallback HTTP générique si aucun nœud spécialisé n'existe.
+- Normalise les données avec des nœuds Set ou Function avant d'écrire dans des destinations externes.

--- a/system/FEW_SHOTS.md
+++ b/system/FEW_SHOTS.md
@@ -1,0 +1,200 @@
+### Exemple 1 — Webhook → Set → Google Sheets
+```json
+{
+  "nodes": [
+    {
+      "id": "1",
+      "name": "Webhook Entrant",
+      "type": "n8n-nodes-base.webhook",
+      "position": { "x": 260, "y": 200 },
+      "parameters": {
+        "path": "incoming-lead",
+        "httpMethod": "POST",
+        "responseMode": "onReceived"
+      }
+    },
+    {
+      "id": "2",
+      "name": "Nettoyage Données",
+      "type": "n8n-nodes-base.set",
+      "position": { "x": 520, "y": 400 },
+      "parameters": {
+        "keepOnlySet": true,
+        "values": {
+          "string": [
+            { "name": "email", "value": "={{$json.body.email}}" },
+            { "name": "source", "value": "Webhook" }
+          ]
+        }
+      }
+    },
+    {
+      "id": "3",
+      "name": "Ajouter à Sheets",
+      "type": "n8n-nodes-base.googleSheets",
+      "position": { "x": 780, "y": 600 },
+      "parameters": {
+        "operation": "append",
+        "sheetId": "={{$env.SHEET_ID}}",
+        "columns": ["email", "source"]
+      },
+      "credentials": {
+        "googleApi": "{{CREDENTIALS.GOOGLE_API}}"
+      }
+    }
+  ],
+  "connections": {
+    "Webhook Entrant": { "main": [[{ "node": "Nettoyage Données", "type": "main", "index": 0 }]] },
+    "Nettoyage Données": { "main": [[{ "node": "Ajouter à Sheets", "type": "main", "index": 0 }]] }
+  },
+  "active": false,
+  "settings": {},
+  "meta": { "template": "lead-intake" },
+  "version": 1
+}
+```
+
+### Exemple 2 — Vision/Transcription → LLM → Sheets
+```json
+{
+  "nodes": [
+    {
+      "id": "1",
+      "name": "Webhook Média",
+      "type": "n8n-nodes-base.webhook",
+      "position": { "x": 260, "y": 200 },
+      "parameters": {
+        "path": "media-upload",
+        "httpMethod": "POST"
+      }
+    },
+    {
+      "id": "2",
+      "name": "Analyser Média",
+      "type": "n8n-nodes-base.openAi",
+      "position": { "x": 520, "y": 400 },
+      "parameters": {
+        "operation": "chat",
+        "model": "gpt-4.1-mini",
+        "inputType": "json",
+        "jsonParameters": true,
+        "messages": [
+          {
+            "role": "system",
+            "content": "Tu es un assistant qui décrit précisément le contenu des médias."
+          },
+          {
+            "role": "user",
+            "content": "={{$json[\"body\"].file}}"
+          }
+        ]
+      },
+      "credentials": {
+        "openAiApi": "{{CREDENTIALS.OPENAI_API}}"
+      }
+    },
+    {
+      "id": "3",
+      "name": "Structurer Résumé",
+      "type": "n8n-nodes-base.set",
+      "position": { "x": 780, "y": 600 },
+      "parameters": {
+        "keepOnlySet": true,
+        "values": {
+          "string": [
+            { "name": "titre", "value": "={{$json.summary.title}}" },
+            { "name": "description", "value": "={{$json.summary.description}}" }
+          ]
+        }
+      }
+    },
+    {
+      "id": "4",
+      "name": "Enregistrer Résumé",
+      "type": "n8n-nodes-base.googleSheets",
+      "position": { "x": 1040, "y": 800 },
+      "parameters": {
+        "operation": "append",
+        "sheetId": "={{$env.SHEET_ID}}",
+        "columns": ["titre", "description"]
+      },
+      "credentials": {
+        "googleApi": "{{CREDENTIALS.GOOGLE_API}}"
+      }
+    }
+  ],
+  "connections": {
+    "Webhook Média": { "main": [[{ "node": "Analyser Média", "type": "main", "index": 0 }]] },
+    "Analyser Média": { "main": [[{ "node": "Structurer Résumé", "type": "main", "index": 0 }]] },
+    "Structurer Résumé": { "main": [[{ "node": "Enregistrer Résumé", "type": "main", "index": 0 }]] }
+  },
+  "active": false,
+  "settings": {},
+  "meta": { "template": "media-summary" },
+  "version": 1
+}
+```
+
+### Exemple 3 — C4 Agent : Plan → Act → Log (fallback HTTP)
+```json
+{
+  "nodes": [
+    {
+      "id": "1",
+      "name": "Déclencheur Plan",
+      "type": "n8n-nodes-base.webhook",
+      "position": { "x": 260, "y": 200 },
+      "parameters": {
+        "path": "c4-plan",
+        "httpMethod": "POST"
+      }
+    },
+    {
+      "id": "2",
+      "name": "Plan d'Actions",
+      "type": "n8n-nodes-base.function",
+      "position": { "x": 520, "y": 400 },
+      "parameters": {
+        "functionCode": "return [{ actions: $json.body.tasks }];"
+      }
+    },
+    {
+      "id": "3",
+      "name": "Exécuter Action",
+      "type": "n8n-nodes-base.httpRequest",
+      "position": { "x": 780, "y": 600 },
+      "parameters": {
+        "url": "={{$json.actions[0].endpoint}}",
+        "method": "POST",
+        "jsonParameters": true,
+        "sendBody": true,
+        "bodyParametersJson": "={{$json.actions[0].payload}}"
+      }
+    },
+    {
+      "id": "4",
+      "name": "Journaliser Résultat",
+      "type": "n8n-nodes-base.googleSheets",
+      "position": { "x": 1040, "y": 800 },
+      "parameters": {
+        "operation": "append",
+        "sheetId": "={{$env.SHEET_ID}}",
+        "columns": ["endpoint", "status", "payload"]
+      },
+      "credentials": {
+        "googleApi": "{{CREDENTIALS.GOOGLE_API}}"
+      },
+      "notes": "Fallback HTTP utilisé si aucun connecteur dédié n'est disponible."
+    }
+  ],
+  "connections": {
+    "Déclencheur Plan": { "main": [[{ "node": "Plan d'Actions", "type": "main", "index": 0 }]] },
+    "Plan d'Actions": { "main": [[{ "node": "Exécuter Action", "type": "main", "index": 0 }]] },
+    "Exécuter Action": { "main": [[{ "node": "Journaliser Résultat", "type": "main", "index": 0 }]] }
+  },
+  "active": false,
+  "settings": {},
+  "meta": { "template": "c4-agent" },
+  "version": 1
+}
+```

--- a/system/SYSTEM_PROMPT.fr.md
+++ b/system/SYSTEM_PROMPT.fr.md
@@ -1,0 +1,14 @@
+Tu es un ingénieur n8n expert. Tu reçois une spécification (texte, image ou vidéo) décrivant un processus métier. Tu dois répondre EXCLUSIVEMENT avec un JSON valide représentant un workflow n8n complet.
+
+Contraintes :
+- Respecte strictement le schéma JSON fourni.
+- Utilise des noms de nœuds explicites, en français si la spec est en français.
+- Assure-toi que chaque `id` est unique et stable.
+- Paramètres minimaux : ne définis que ce qui est nécessaire au fonctionnement.
+- Refuse toute propriété hors schéma (aucune clé supplémentaire).
+- Assure-toi que le workflow est autonome, cohérent et directement importable dans n8n.
+- Utilise uniquement les nœuds autorisés.
+- Respecte les heuristiques : atomicité des tâches, connexions complètes, fallback HTTP si un nœud dédié manque, normalisation via Set/Function lorsque pertinent.
+
+Sortie :
+- Un objet JSON unique conforme au schéma `n8n-workflow.schema.json`.


### PR DESCRIPTION
## Résumé
- ajouter les prompts système, développeur et few-shots pour cadrer la génération n8n
- définir un schéma JSON strict ainsi que les types TypeScript associés
- implémenter les scripts de génération/validation et fournir des exemples de workflows prêts à valider

## Tests
- `pnpm val src/examples/basic-webhook.json` *(échoue : dépendances non installées car accès registry npm interdit)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb40891f48324992c90af1c578251